### PR TITLE
Fix a bug preventing using the module without choosing a scope and subscope

### DIFF
--- a/app/models/decidim/ideas/idea.rb
+++ b/app/models/decidim/ideas/idea.rb
@@ -162,7 +162,7 @@ module Decidim
         scopes_table = ([empty_scope_select] + scope_selects).join(" UNION ALL ")
 
         joins("LEFT JOIN decidim_scopes AS area_scopes ON area_scopes.id = decidim_ideas_ideas.area_scope_id")
-          .joins("LEFT JOIN (#{scope_selects.join(" UNION ALL ")}) AS scope_coordinates ON scope_coordinates.scope_id = area_scopes.id")
+          .joins("LEFT JOIN (#{scopes_table}) AS scope_coordinates ON scope_coordinates.scope_id = area_scopes.id")
       end
 
       def self.newsletter_participant_ids(component)


### PR DESCRIPTION
When using the module with scope set as Global, accessing the index page will give you the following error:

```
PG::SyntaxError: ERROR: syntax error at or near ")" LINE 1: ...id = decidim_ideas_ideas.area_scope_id LEFT JOIN () AS scope... ^ : SELECT "decidim_ideas_ideas"."id", "decidim_ideas_ideas"."title", "decidim_ideas_ideas"."body", CASE WHEN CHAR_LENGTH(decidim_ideas_ideas.address::text) > 0 THEN decidim_ideas_ideas.address ELSE area_scopes.name->>'en' END, CASE WHEN decidim_ideas_ideas.latitude IS NOT NULL THEN decidim_ideas_ideas.latitude ELSE scope_coordinates.latitude END, CASE WHEN decidim_ideas_ideas.latitude IS NOT NULL THEN decidim_ideas_ideas.longitude ELSE scope_coordinates.longitude END FROM "decidim_ideas_ideas" LEFT JOIN decidim_scopes AS area_scopes ON area_scopes.id = decidim_ideas_ideas.area_scope_id LEFT JOIN () AS scope_coordinates ON scope_coordinates.scope_id = area_scopes.id LEFT OUTER JOIN "decidim_moderations" ON "decidim_moderations"."decidim_reportable_id" = "decidim_ideas_ideas"."id" AND "decidim_moderations"."decidim_reportable_type" = $1 WHERE 1=0 AND "decidim_ideas_ideas"."published_at" IS NOT NULL AND "decidim_moderations"."hidden_at" IS NULL
```

I had a look and quickly saw that you planned for that case but apparently the implementation isn't complete as you are never using the array `scopes_table` that you create.

This PR fixes the issue, allowing you to use the module scopeless:

<img width="730" alt="image" src="https://user-images.githubusercontent.com/7223028/103522883-4fb2e480-4e7b-11eb-9cbc-7f6693b74f85.png">
